### PR TITLE
Add possibility to drain node if contain emptydir-data

### DIFF
--- a/roles/drain_nodes/defaults/main.yml
+++ b/roles/drain_nodes/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
 drain_node: true
 reboot_node: false
+delete_emptydir_data: false
 delete_local_data: false

--- a/roles/drain_nodes/tasks/main.yml
+++ b/roles/drain_nodes/tasks/main.yml
@@ -3,6 +3,9 @@
   command: >-
     kubectl drain
     --ignore-daemonsets
+    {% if delete_emptydir_data|bool %}
+    --delete-emptydir-data
+    {% endif %}
     {% if delete_local_data|bool %}
     --delete-local-data
     {% endif %}


### PR DESCRIPTION
Actually if release on node use emptyDir this one can't be drain.
I add this var for authorize it in case of needs