### PR TITLE
Add more drain options

### DIFF
--- a/roles/drain_nodes/defaults/main.yml
+++ b/roles/drain_nodes/defaults/main.yml
@@ -2,3 +2,4 @@
 drain_node: true
 reboot_node: false
 delete_local_data: false
+pause_after_drain: false

--- a/roles/drain_nodes/defaults/main.yml
+++ b/roles/drain_nodes/defaults/main.yml
@@ -3,3 +3,4 @@ drain_node: true
 reboot_node: false
 delete_local_data: false
 pause_after_drain: false
+drain_force: false

--- a/roles/drain_nodes/handlers/main.yml
+++ b/roles/drain_nodes/handlers/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: 'Pause after drain'
+  pause:
+  when: pause_after_drain|bool
+
 - name: 'Reboot node'
   reboot:
   when: reboot_node|bool

--- a/roles/drain_nodes/tasks/main.yml
+++ b/roles/drain_nodes/tasks/main.yml
@@ -10,6 +10,7 @@
   delegate_to: '{{ cp_node }}'
   when: drain_node|bool
   notify:
+  - Pause after drain
   - Reboot node
   - Wait for node
   - Uncordon node

--- a/roles/drain_nodes/tasks/main.yml
+++ b/roles/drain_nodes/tasks/main.yml
@@ -6,6 +6,9 @@
     {% if delete_local_data|bool %}
     --delete-local-data
     {% endif %}
+    {% if drain_force|bool %}
+    --force
+    {% endif %}
     {{ ansible_nodename }}
   delegate_to: '{{ cp_node }}'
   when: drain_node|bool


### PR DESCRIPTION
Add two variables, one to pause the playbook after a node drain and another to use the `--force` option on kubectl drain.