### PR TITLE
Fix kubelet config diff on cluster init

### DIFF
--- a/roles/preflight_check_nodes/tasks/main.yml
+++ b/roles/preflight_check_nodes/tasks/main.yml
@@ -52,6 +52,6 @@
             '{{ host }}',
         {%- endfor -%}
         {%- for host in ansible_play_hosts
-            if hostvars[host].kubelet_config_diff.diff_lines|length > 0 -%}
+            if hostvars[host].kubelet_config_diff.diff_lines|default([])|length > 0 -%}
               '{{ host }}',
         {%- endfor -%} ]


### PR DESCRIPTION
Variable doesn't exist if the previous task is skipped.