### PR TITLE
Fix error on filter name choice between role and collection

### DIFF
--- a/roles/bootstrap_token/tasks/bootstrap_token.yml
+++ b/roles/bootstrap_token/tasks/bootstrap_token.yml
@@ -19,7 +19,7 @@
 - name: 'Filter expire token'
   set_fact:
     valid_bootstrap_tokens: >-
-      {%- if 'bootstrap_token_valid' is filter -%}
+      {%- if ansible_collection_name is defined -%}
         {%- set filter_name = "bootstrap_token_valid" -%}
       {%- else -%}
         {%- set filter_name = "enix.kubeadm.bootstrap_token_valid" -%}


### PR DESCRIPTION
With newer Ansible version, the `is filter` condition raise a KeyError when used in a context of a collection as it trigger a lookup on a filter that didn't exist.

So replace the condition used to determine if we're in a collection with one without side effect.